### PR TITLE
updated embedding model and destination connector

### DIFF
--- a/import.sh
+++ b/import.sh
@@ -25,11 +25,10 @@ unstructured-ingest \
     --partition-endpoint $UNSTRUCTURED_API_URL \
     --metadata-include "$metadata_includes" \
     --additional-partition-args="{\"split_pdf_page\":\"true\", \"split_pdf_allow_failed\":\"true\", \"split_pdf_concurrency_level\": 15}" \
-  sql \
+  postgres \
     --db-type $SQL_DB_TYPE \
     --username $PGUSER \
     --password $PGPASSWORD \
     --host $PGHOST \
     --port $PGPORT \
     --database $PGDATABASE
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 unstructured[all-docs]
 unstructured-ingest
-unstructured-ingest[postgresql]
+unstructured-ingest[postgres]

--- a/schema-with-vectorizer.sql
+++ b/schema-with-vectorizer.sql
@@ -1,9 +1,6 @@
 CREATE EXTENSION IF NOT EXISTS ai CASCADE;
 
-DROP TABLE elements cascade;
-TRUNCATE ai.vectorizer cascade;
-DROP TABLE IF EXISTS elements_embedding_oai_ada2_store ;
-
+-- Create the table for the elements (source table)
 CREATE TABLE IF NOT EXISTS elements (
     id UUID PRIMARY KEY,
     element_id TEXT,
@@ -45,9 +42,10 @@ CREATE TABLE IF NOT EXISTS elements (
     detection_class_prob DECIMAL
 );
 
+-- Create the pgai Vectorizer for the source table
 SELECT ai.create_vectorizer(
-    'public.elements'::regclass, destination => 'elements_embedding_oai_ada2'
-  , embedding=>ai.embedding_openai('text-embedding-ada-002', 1536)
+    'public.elements'::regclass
+  , embedding=>ai.embedding_openai('text-embedding-3-small', 1536)
   , chunking=>ai.chunking_recursive_character_text_splitter('text')
   , formatting=>ai.formatting_python_template('type: $type, url: $url, chunk: $chunk')
 );


### PR DESCRIPTION
* Changed the embedding model from `text-embedding-ada-002` to `text-embedding-3-small`.

* Updated the destination connector to `postgres` from `sql` as the new [Unstructured documentation](https://docs.unstructured.io/api-reference/ingest/destination-connector/postgresql) indicates.